### PR TITLE
docs : #4 GET /partners API 명세서 작성 

### DIFF
--- a/docs/partners/partners.swagger.ts
+++ b/docs/partners/partners.swagger.ts
@@ -1,0 +1,12 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { PartnersResponseDto } from 'src/partners/dtos/partners-response.dto';
+
+export function GetPartnersDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '협력사 정보 가져오기',
+    }),
+    ApiOkResponse({ type: [PartnersResponseDto] }),
+  );
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/swagger": "^6.1.2",
     "@nestjs/typeorm": "^9.0.1",
     "pg": "^8.8.0",
     "reflect-metadata": "^0.1.13",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,11 +4,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { typeORMFactory } from 'src/configs/typeorm.config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PartnersModule } from './partners/partners.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRootAsync(typeORMFactory),
+    PartnersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/configs/swagger.config.ts
+++ b/src/configs/swagger.config.ts
@@ -1,0 +1,9 @@
+import { DocumentBuilder } from '@nestjs/swagger';
+
+export const appVersion = '1.0';
+
+export const swaggerConfig = new DocumentBuilder()
+  .setTitle('SOPT Official API Docs')
+  .setDescription('The SOPT official page API description')
+  .setVersion(appVersion)
+  .build();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,12 @@
 import { NestFactory } from '@nestjs/core';
+import { SwaggerModule } from '@nestjs/swagger';
+import { swaggerConfig } from 'src/configs/swagger.config';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api-docs', app, document);
   await app.listen(3000);
 }
 bootstrap();

--- a/src/partners/controllers/partners.controller.ts
+++ b/src/partners/controllers/partners.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('partners')
+export class PartnersController {
+  @Get()
+  async getPartners() {
+    return 'GET /partners';
+  }
+}

--- a/src/partners/controllers/partners.controller.ts
+++ b/src/partners/controllers/partners.controller.ts
@@ -1,13 +1,20 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetPartnersDocs } from 'docs/partners/partners.swagger';
+import { PartnersResponseDto } from 'src/partners/dtos/partners-response.dto';
 
 @Controller('partners')
 @ApiTags('Partner')
 export class PartnersController {
   @Get('')
   @GetPartnersDocs()
-  async getPartners() {
-    return 'GET /partners';
+  async getPartners(): Promise<[PartnersResponseDto]> {
+    const mockPartner: PartnersResponseDto = {
+      id: 1,
+      name: 'Naver D2',
+      image:
+        'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/partners/logo/1660976077325_3EGL__X9xnpjgH3i49kKF.png',
+    };
+    return [mockPartner];
   }
 }

--- a/src/partners/controllers/partners.controller.ts
+++ b/src/partners/controllers/partners.controller.ts
@@ -1,8 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { GetPartnersDocs } from 'docs/partners/partners.swagger';
 
 @Controller('partners')
+@ApiTags('Partner')
 export class PartnersController {
-  @Get()
+  @Get('')
+  @GetPartnersDocs()
   async getPartners() {
     return 'GET /partners';
   }

--- a/src/partners/dtos/partners-response.dto.ts
+++ b/src/partners/dtos/partners-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PartnersResponseDto {
+  @ApiProperty({ type: Number, required: true })
+  id: number;
+
+  @ApiProperty({ type: String, required: true })
+  name: string;
+
+  @ApiProperty({ type: String, required: true })
+  image: string;
+}

--- a/src/partners/partners.module.ts
+++ b/src/partners/partners.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { PartnersController } from './controllers/partners.controller';
+
+@Module({
+  controllers: [PartnersController],
+})
+export class PartnersModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,6 +722,11 @@
     tslib "2.4.0"
     uuid "9.0.0"
 
+"@nestjs/mapped-types@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz#54a9fa61079635dd6c3c75fd9593f20b2302a55b"
+  integrity sha512-+2kSly4P1QI+9eGt+/uGyPdEG1hVz7nbpqPHWZVYgoqz8eOHljpXPag+UCVRw9zo2XCu4sgNUIGe8Uk0+OvUQg==
+
 "@nestjs/platform-express@^9.0.0":
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/@nestjs/platform-express/-/platform-express-9.1.1.tgz#2cdd65fd04214a85e4e48649fece88803b4a5672"
@@ -743,6 +748,17 @@
     fs-extra "10.1.0"
     jsonc-parser "3.2.0"
     pluralize "8.0.0"
+
+"@nestjs/swagger@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/swagger/-/swagger-6.1.2.tgz#5eb9c134fc976f16c139ecaf80a7f02a5d33da46"
+  integrity sha512-RU1DeTDyuN/lRXKFWaf7I9LYF34/ale3IIGeY3romAcXL/N9W0+50Ek3ou+Ajd5FqpLqzt7saYhnaQegVuU4UQ==
+  dependencies:
+    "@nestjs/mapped-types" "1.1.0"
+    js-yaml "4.1.0"
+    lodash "4.17.21"
+    path-to-regexp "3.2.0"
+    swagger-ui-dist "4.14.0"
 
 "@nestjs/testing@^9.0.0":
   version "9.1.1"
@@ -3247,6 +3263,13 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-yaml@4.1.0, js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -3254,13 +3277,6 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -4445,6 +4461,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+swagger-ui-dist@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-4.14.0.tgz#e34d807464eb84578c43902e393084a1a6fbda52"
+  integrity sha512-TBzhheU15s+o54Cgk9qxuYcZMiqSm/SkvKnapoGHOF66kz0Y5aGjpzj5BT/vpBbn6rTPJ9tUYXQxuDWfsjiGMw==
 
 symbol-observable@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
- #4 

## 📌 개발 이유
프론트엔드와의 원활한 협업을 위해 API 명세서를 작성했습니다. 
API 명세서는 Swagger의 형태로 작성했습니다. 

## 💻 수정 사항
- 프로젝트에 swagger 설정을 완료했습니다. 
- partners 모듈과 partners.controller를 생성했습니다. 
- GET /partners API에 대한 ResponseDto를 작성하고 API 명세서를 작성했습니다. 

## 🧪 테스트 방법
- 해당 브랜치를 pull 받고 yarn run start:dev를 통해 서버를 실행시켜주세요
- localhost:3000/api-docs로 이동해 GET /partners API 명세서가 작성되었는지 확인합니다. 
- swagger 상에서 execute를 통해 Mock API 가 잘 동작하는지 확인합니다. 

## ⛳️ 고민한 점 || 궁굼한 점
- 우선 swagger 설정을 develop 브랜치에 빠르게 반영하는게 좋을 것 같아서 PR 작성했습니다! 

## 🎯 리뷰 포인트
- @getPartnersDocs 데코레이터를 만들어 문서화에 필요한 코드를 분리했습니다. 이름이 적절한지 봐주세요! 

## 📁 레퍼런스
- https://docs.nestjs.com/openapi/introduction