### PR TITLE
docs : #4 logo, partner, cooperation-project, project API 명세서 작성

### DIFF
--- a/docs/cooperation-projects/cooperation-projects.swagger.ts
+++ b/docs/cooperation-projects/cooperation-projects.swagger.ts
@@ -7,6 +7,6 @@ export function GetCooperationProjectsDocs() {
     ApiOperation({
       summary: '협력사와 진행한 프로젝트 조회',
     }),
-    ApiOkResponse({ type: [CooperationProjectsResponseDto] }),
+    ApiOkResponse({ type: Array<CooperationProjectsResponseDto> }),
   );
 }

--- a/docs/cooperation-projects/cooperation-projects.swagger.ts
+++ b/docs/cooperation-projects/cooperation-projects.swagger.ts
@@ -1,0 +1,12 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { CooperationProjectsResponseDto } from 'src/cooperation-projects/dtos/cooperation-projects-response.dto';
+
+export function GetCooperationProjectsDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '협력사와 진행한 프로젝트 조회',
+    }),
+    ApiOkResponse({ type: [CooperationProjectsResponseDto] }),
+  );
+}

--- a/docs/logos/logos.swagger.ts
+++ b/docs/logos/logos.swagger.ts
@@ -7,6 +7,6 @@ export function GetLogosDocs() {
     ApiOperation({
       summary: '프로젝트 로고 조회',
     }),
-    ApiOkResponse({ type: [LogosResponseDto] }),
+    ApiOkResponse({ type: Array<LogosResponseDto> }),
   );
 }

--- a/docs/logos/logos.swagger.ts
+++ b/docs/logos/logos.swagger.ts
@@ -1,0 +1,12 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { LogosResponseDto } from 'src/logos/dtos/logos-response.dto';
+
+export function GetLogosDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로젝트 로고 조회',
+    }),
+    ApiOkResponse({ type: [LogosResponseDto] }),
+  );
+}

--- a/docs/partners/partners.swagger.ts
+++ b/docs/partners/partners.swagger.ts
@@ -7,6 +7,6 @@ export function GetPartnersDocs() {
     ApiOperation({
       summary: '협력사 정보 가져오기',
     }),
-    ApiOkResponse({ type: [PartnersResponseDto] }),
+    ApiOkResponse({ type: Array<PartnersResponseDto> }),
   );
 }

--- a/docs/projects/projects.swagger.ts
+++ b/docs/projects/projects.swagger.ts
@@ -1,0 +1,50 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { ProjectsListResponseDto } from 'src/projects/dtos/projects-list-response.dto';
+import { ProjectsResponseDto } from 'src/projects/dtos/projects-response.dto';
+
+export function GetProjectsDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로젝트 정보 전부 가져오기',
+    }),
+    ApiQuery({
+      name: 'limit',
+      type: Number,
+      required: true,
+      description: '한번에 가져올 데이터',
+    }),
+    ApiQuery({
+      name: 'page',
+      type: Number,
+      required: true,
+      description: '가져올 페이지 수',
+    }),
+    ApiQuery({
+      name: 'filter',
+      type: String,
+      required: false,
+      description: '필터 유형. 추후 다중 필터 설정 가능 예정',
+    }),
+    ApiOkResponse({ type: ProjectsListResponseDto }),
+  );
+}
+
+export function GetProjectDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '특정 프로젝트 정보 가져오기',
+    }),
+    ApiParam({
+      name: 'projectId',
+      type: Number,
+      description: '가져올 프로젝트의 Id',
+    }),
+    ApiOkResponse({ type: ProjectsResponseDto }),
+  );
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PartnersModule } from './partners/partners.module';
 import { LogosModule } from './logos/logos.module';
+import { CooperationProjectsModule } from './cooperation-projects/cooperation-projects.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { LogosModule } from './logos/logos.module';
     TypeOrmModule.forRootAsync(typeORMFactory),
     PartnersModule,
     LogosModule,
+    CooperationProjectsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,12 +5,14 @@ import { typeORMFactory } from 'src/configs/typeorm.config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PartnersModule } from './partners/partners.module';
+import { LogosModule } from './logos/logos.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRootAsync(typeORMFactory),
     PartnersModule,
+    LogosModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { AppService } from './app.service';
 import { PartnersModule } from './partners/partners.module';
 import { LogosModule } from './logos/logos.module';
 import { CooperationProjectsModule } from './cooperation-projects/cooperation-projects.module';
+import { ProjectsModule } from './projects/projects.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { CooperationProjectsModule } from './cooperation-projects/cooperation-pr
     PartnersModule,
     LogosModule,
     CooperationProjectsModule,
+    ProjectsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/cooperation-projects/controllers/cooperation-projects.controller.ts
+++ b/src/cooperation-projects/controllers/cooperation-projects.controller.ts
@@ -8,7 +8,9 @@ import { CooperationProjectsResponseDto } from 'src/cooperation-projects/dtos/co
 export class CooperationProjectsController {
   @Get()
   @GetCooperationProjectsDocs()
-  async getCooperationProjects(): Promise<[CooperationProjectsResponseDto]> {
+  async getCooperationProjects(): Promise<
+    Array<CooperationProjectsResponseDto>
+  > {
     const mockCooperationProject: CooperationProjectsResponseDto = {
       id: 11,
       year: 2022,

--- a/src/cooperation-projects/controllers/cooperation-projects.controller.ts
+++ b/src/cooperation-projects/controllers/cooperation-projects.controller.ts
@@ -1,8 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { GetCooperationProjectsDocs } from 'docs/cooperation-projects/cooperation-projects.swagger';
 
+@ApiTags('CooperationProject')
 @Controller('cooperation-projects')
 export class CooperationProjectsController {
   @Get()
+  @GetCooperationProjectsDocs()
   async getCooperationProjects() {
     return 'GET /cooperation-projects';
   }

--- a/src/cooperation-projects/controllers/cooperation-projects.controller.ts
+++ b/src/cooperation-projects/controllers/cooperation-projects.controller.ts
@@ -1,13 +1,23 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetCooperationProjectsDocs } from 'docs/cooperation-projects/cooperation-projects.swagger';
+import { CooperationProjectsResponseDto } from 'src/cooperation-projects/dtos/cooperation-projects-response.dto';
 
 @ApiTags('CooperationProject')
 @Controller('cooperation-projects')
 export class CooperationProjectsController {
   @Get()
   @GetCooperationProjectsDocs()
-  async getCooperationProjects() {
-    return 'GET /cooperation-projects';
+  async getCooperationProjects(): Promise<[CooperationProjectsResponseDto]> {
+    const mockCooperationProject: CooperationProjectsResponseDto = {
+      id: 11,
+      year: 2022,
+      title: 'KB D.N.A 프로젝트',
+      content: `KB금융그룹과 SOPT, 디지털 전문가가 협업하여 KB 디지털 프로젝트의 개선과제를 발굴하고, 이를 해결하기 위한 구체적인 아이디어를 도출해 프로토타입을 제작하는 프로젝트`,
+      subContent: '2018년부터 총 5회 진행',
+      posterImage:
+        'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/partners/poster/1661005789051_chHEt5ezSXlTRKfHmRnRv.png',
+    };
+    return [mockCooperationProject];
   }
 }

--- a/src/cooperation-projects/controllers/cooperation-projects.controller.ts
+++ b/src/cooperation-projects/controllers/cooperation-projects.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('cooperation-projects')
+export class CooperationProjectsController {
+  @Get()
+  async getCooperationProjects() {
+    return 'GET /cooperation-projects';
+  }
+}

--- a/src/cooperation-projects/cooperation-projects.module.ts
+++ b/src/cooperation-projects/cooperation-projects.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { CooperationProjectsController } from './controllers/cooperation-projects.controller';
+
+@Module({
+  controllers: [CooperationProjectsController],
+})
+export class CooperationProjectsModule {}

--- a/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
+++ b/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
@@ -34,7 +34,7 @@ export class CooperationProjectsResponseDto {
     required: false,
     description: '프로젝트에 대한 추가 정보',
   })
-  subContent: string;
+  subContent?: string;
 
   @ApiProperty({
     type: String,

--- a/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
+++ b/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CooperationProjectsResponseDto {
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: '협력사와 진행한 프로젝트의 Id',
+  })
+  id: number;
+
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: '프로젝트를 진행한 연도',
+  })
+  year: number;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트의 이름',
+  })
+  title: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트에 대한 설명',
+  })
+  content: string;
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: '프로젝트에 대한 추가 정보',
+  })
+  subContent: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '협력사와 진행한 프로젝트의 포스터 이미지',
+  })
+  posterImage: string;
+}

--- a/src/logos/controllers/logos.controller.ts
+++ b/src/logos/controllers/logos.controller.ts
@@ -1,8 +1,11 @@
 import { Controller, Get } from '@nestjs/common';
-
+import { ApiTags } from '@nestjs/swagger';
+import { GetLogosDocs } from 'docs/logos/logos.swagger';
+@ApiTags('Logos')
 @Controller('logos')
 export class LogosController {
   @Get('')
+  @GetLogosDocs()
   async getLogos() {
     return 'GET /logos';
   }

--- a/src/logos/controllers/logos.controller.ts
+++ b/src/logos/controllers/logos.controller.ts
@@ -7,7 +7,7 @@ import { LogosResponseDto } from 'src/logos/dtos/logos-response.dto';
 export class LogosController {
   @Get('')
   @GetLogosDocs()
-  async getLogos(): Promise<[LogosResponseDto]> {
+  async getLogos(): Promise<Array<LogosResponseDto>> {
     const mockLogo: LogosResponseDto = {
       id: 1,
       image:

--- a/src/logos/controllers/logos.controller.ts
+++ b/src/logos/controllers/logos.controller.ts
@@ -1,12 +1,18 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetLogosDocs } from 'docs/logos/logos.swagger';
+import { LogosResponseDto } from 'src/logos/dtos/logos-response.dto';
 @ApiTags('Logos')
 @Controller('logos')
 export class LogosController {
   @Get('')
   @GetLogosDocs()
-  async getLogos() {
-    return 'GET /logos';
+  async getLogos(): Promise<[LogosResponseDto]> {
+    const mockLogo: LogosResponseDto = {
+      id: 1,
+      image:
+        'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/logo/1660922410081_AvI196XNRbXdWXpWQKlkg.png',
+    };
+    return [mockLogo];
   }
 }

--- a/src/logos/controllers/logos.controller.ts
+++ b/src/logos/controllers/logos.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('logos')
+export class LogosController {
+  @Get('')
+  async getLogos() {
+    return 'GET /logos';
+  }
+}

--- a/src/logos/dtos/logos-response.dto.ts
+++ b/src/logos/dtos/logos-response.dto.ts
@@ -1,9 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class LogosResponseDto {
-  @ApiProperty({ type: Number, required: true })
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: 'logo의 Id',
+  })
   id: number;
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'logo 이미지의 url 주소',
+  })
   image: string;
 }

--- a/src/logos/dtos/logos-response.dto.ts
+++ b/src/logos/dtos/logos-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LogosResponseDto {
+  @ApiProperty({ type: Number, required: true })
+  id: number;
+
+  @ApiProperty({ type: String, required: true })
+  image: string;
+}

--- a/src/logos/logos.module.ts
+++ b/src/logos/logos.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { LogosController } from 'src/logos/controllers/logos.controller';
+
+@Module({
+  controllers: [LogosController],
+})
+export class LogosModule {}

--- a/src/partners/controllers/partners.controller.ts
+++ b/src/partners/controllers/partners.controller.ts
@@ -8,7 +8,7 @@ import { PartnersResponseDto } from 'src/partners/dtos/partners-response.dto';
 export class PartnersController {
   @Get('')
   @GetPartnersDocs()
-  async getPartners(): Promise<[PartnersResponseDto]> {
+  async getPartners(): Promise<Array<PartnersResponseDto>> {
     const mockPartner: PartnersResponseDto = {
       id: 1,
       name: 'Naver D2',

--- a/src/projects/controllers/projects.controller.ts
+++ b/src/projects/controllers/projects.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('projects')
+export class ProjectsController {
+  @Get()
+  async getProjects() {
+    return 'GET /projects';
+  }
+
+  @Get('/:projectId')
+  async getProject() {
+    return 'GEt /projects/:projectId';
+  }
+}

--- a/src/projects/controllers/projects.controller.ts
+++ b/src/projects/controllers/projects.controller.ts
@@ -4,19 +4,68 @@ import {
   GetProjectDocs,
   GetProjectsDocs,
 } from 'docs/projects/projects.swagger';
+import { ProjectsListResponseDto } from 'src/projects/dtos/projects-list-response.dto';
+import { ProjectsResponseDto } from 'src/projects/dtos/projects-response.dto';
 
 @ApiTags('Project')
 @Controller('projects')
 export class ProjectsController {
+  mockProjectsResponseDto: ProjectsResponseDto = {
+    id: 1,
+    name: '테스트 프로젝트',
+    semester: 30,
+    isProvidingService: true,
+    isBusinessing: false,
+    teamMembers: [
+      {
+        name: '이정연',
+        role: 'Project Manager',
+        roleDetail:
+          'API 명세서 작성 및 서버 구축 및 AI 설계 근데 이제 엄청 엄청 긴 세줄을 만들기 위해 추가 설명을 곁들인 ',
+      },
+      {
+        name: '정예린',
+        role: 'Project Designer',
+        roleDetail: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
+      },
+    ],
+    afterJoinedTeamMembers: [
+      {
+        name: '정예린',
+        role: 'Project Designer',
+        roleDetail: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
+      },
+      {
+        name: '정예린',
+        role: 'Project Designer',
+        roleDetail: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
+      },
+    ],
+    serviceType: ['WEB', 'APP'],
+    startDate: new Date(),
+    endDate: new Date(),
+    inProgress: false,
+    shortIntroduction: '테스트 프로젝트입니다.',
+    detail:
+      '테스트프로젝트는 영국에서 시작되어 8년이 지나 대한민국으로 들어왔습니다. 이 편지를 본 당신은 행운이 가득하고 모든일이 잘 될겁니다.',
+    logoImageUrl:
+      'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/logo/1660922410081_AvI196XNRbXdWXpWQKlkg.png',
+    link: [{ type: 'github', url: 'https://github.com/TAKE-US/TAKEUS-BACK' }],
+  };
+
   @Get('')
   @GetProjectsDocs()
-  async getProjects() {
-    return 'GET /projects';
+  async getProjects(): Promise<ProjectsListResponseDto> {
+    const mockProjectsListResponse: ProjectsListResponseDto = {
+      projects: [this.mockProjectsResponseDto, this.mockProjectsResponseDto],
+      hasMore: false,
+    };
+    return mockProjectsListResponse;
   }
 
   @Get('/:projectId')
   @GetProjectDocs()
-  async getProject() {
-    return 'GET /projects/:projectId';
+  async getProject(): Promise<ProjectsResponseDto> {
+    return this.mockProjectsResponseDto;
   }
 }

--- a/src/projects/controllers/projects.controller.ts
+++ b/src/projects/controllers/projects.controller.ts
@@ -1,14 +1,22 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import {
+  GetProjectDocs,
+  GetProjectsDocs,
+} from 'docs/projects/projects.swagger';
 
+@ApiTags('Project')
 @Controller('projects')
 export class ProjectsController {
-  @Get()
+  @Get('')
+  @GetProjectsDocs()
   async getProjects() {
     return 'GET /projects';
   }
 
   @Get('/:projectId')
+  @GetProjectDocs()
   async getProject() {
-    return 'GEt /projects/:projectId';
+    return 'GET /projects/:projectId';
   }
 }

--- a/src/projects/controllers/projects.controller.ts
+++ b/src/projects/controllers/projects.controller.ts
@@ -58,7 +58,7 @@ export class ProjectsController {
   async getProjects(): Promise<ProjectsListResponseDto> {
     const mockProjectsListResponse: ProjectsListResponseDto = {
       projects: [this.mockProjectsResponseDto, this.mockProjectsResponseDto],
-      hasMore: false,
+      isEnd: false,
     };
     return mockProjectsListResponse;
   }

--- a/src/projects/dtos/link.ts
+++ b/src/projects/dtos/link.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Link {
+  @ApiProperty({
+    type: String,
+    required: true,
+    description:
+      '웹사이트, 구글 플레이스토어, 앱스토어, Github, 발표영상 등 프로젝트에 관련된 링크의 종류',
+  })
+  type: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '링크의 url 주소',
+  })
+  url: string;
+}

--- a/src/projects/dtos/projects-list-response.dto.ts
+++ b/src/projects/dtos/projects-list-response.dto.ts
@@ -3,10 +3,10 @@ import { ProjectsResponseDto } from 'src/projects/dtos/projects-response.dto';
 
 export class ProjectsListResponseDto {
   @ApiProperty({
-    type: [ProjectsResponseDto],
+    type: Array<ProjectsResponseDto>,
     required: true,
   })
-  projects: [ProjectsResponseDto];
+  projects: Array<ProjectsResponseDto>;
 
   @ApiProperty({
     type: Boolean,

--- a/src/projects/dtos/projects-list-response.dto.ts
+++ b/src/projects/dtos/projects-list-response.dto.ts
@@ -14,5 +14,5 @@ export class ProjectsListResponseDto {
     description:
       '추가 정보 유무. 더 가져올 데이터가 있으면 true, 더 가져올 데이터가 없는 경우 false',
   })
-  hasMore: boolean;
+  isEnd: boolean;
 }

--- a/src/projects/dtos/projects-list-response.dto.ts
+++ b/src/projects/dtos/projects-list-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ProjectsResponseDto } from 'src/projects/dtos/projects-response.dto';
+
+export class ProjectsListResponseDto {
+  @ApiProperty({
+    type: [ProjectsResponseDto],
+    required: true,
+  })
+  projects: [ProjectsResponseDto];
+
+  @ApiProperty({
+    type: Boolean,
+    required: true,
+    description:
+      '추가 정보 유무. 더 가져올 데이터가 있으면 true, 더 가져올 데이터가 없는 경우 false',
+  })
+  hasMore: boolean;
+}

--- a/src/projects/dtos/projects-response.dto.ts
+++ b/src/projects/dtos/projects-response.dto.ts
@@ -1,0 +1,124 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Link } from 'src/projects/dtos/link';
+import { ProjectsTeamMember } from 'src/projects/dtos/projects-team-member';
+
+export class ProjectsResponseDto {
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: '프로젝트의 Id',
+  })
+  id: number;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트의 이름',
+  })
+  name: string;
+
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: '프로젝트가 진행된 기수',
+  })
+  semester: number;
+
+  @ApiProperty({
+    type: Boolean,
+    required: true,
+    description: '프로젝트의 서비스 진행 여부',
+  })
+  isProvidingService: boolean;
+
+  @ApiProperty({
+    type: Boolean,
+    required: true,
+    description: '프로젝트의 창업 여부',
+  })
+  isBusinessing: boolean;
+
+  @ApiProperty({
+    type: [ProjectsTeamMember],
+    required: false,
+    description: '프로젝트의 팀원',
+  })
+  teamMembers?: [ProjectsTeamMember];
+
+  @ApiProperty({
+    type: [ProjectsTeamMember],
+    required: false,
+    description: '추가 합류한 팀원',
+  })
+  afterJoinedTeamMembers?: [ProjectsTeamMember];
+
+  @ApiProperty({
+    type: [String],
+    required: true,
+    description: '서비스 형태',
+  })
+  serviceType: [string];
+
+  @ApiProperty({
+    type: Date,
+    required: true,
+    description: '프로젝트 시작 날짜',
+  })
+  startDate: Date;
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: '프로젝트 종료 날짜. 프로젝트가 진행중 일 경우 값 없음',
+  })
+  endDate?: Date;
+
+  @ApiProperty({
+    type: Boolean,
+    required: true,
+    description: '프로젝트의 진행중 여부',
+  })
+  inProgress: boolean;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트 한줄소개',
+  })
+  shortIntroduction: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트 설명',
+  })
+  detail: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트 로고 이미지 URL',
+  })
+  logoImageUrl: string;
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: '프로젝트 썸네일 이미지 URL',
+  })
+  thumbnailImageUrl?: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트 이미지 URL',
+  })
+  projectImageUrl?: string;
+
+  @ApiProperty({
+    type: [Link],
+    required: true,
+    description: '프로젝트 링크',
+  })
+  link?: [Link];
+}

--- a/src/projects/dtos/projects-response.dto.ts
+++ b/src/projects/dtos/projects-response.dto.ts
@@ -39,25 +39,25 @@ export class ProjectsResponseDto {
   isBusinessing: boolean;
 
   @ApiProperty({
-    type: [ProjectsTeamMember],
+    type: Array<ProjectsTeamMember>,
     required: false,
     description: '프로젝트의 팀원',
   })
-  teamMembers?: [ProjectsTeamMember];
+  teamMembers?: Array<ProjectsTeamMember>;
 
   @ApiProperty({
-    type: [ProjectsTeamMember],
+    type: Array<ProjectsTeamMember>,
     required: false,
     description: '추가 합류한 팀원',
   })
-  afterJoinedTeamMembers?: [ProjectsTeamMember];
+  afterJoinedTeamMembers?: Array<ProjectsTeamMember>;
 
   @ApiProperty({
-    type: [String],
+    type: Array<string>,
     required: true,
     description: '서비스 형태',
   })
-  serviceType: [string];
+  serviceType: Array<string>;
 
   @ApiProperty({
     type: Date,
@@ -116,9 +116,9 @@ export class ProjectsResponseDto {
   projectImageUrl?: string;
 
   @ApiProperty({
-    type: [Link],
+    type: Array<Link>,
     required: true,
     description: '프로젝트 링크',
   })
-  link?: [Link];
+  link?: Array<Link>;
 }

--- a/src/projects/dtos/projects-team-member.ts
+++ b/src/projects/dtos/projects-team-member.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProjectsTeamMember {
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트 팀원 이름',
+  })
+  name: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트 팀원의 역할',
+  })
+  role: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: '프로젝트 팀원의 역할 상세설명',
+  })
+  roleDetail: string;
+}

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ProjectsController } from './controllers/projects.controller';
+
+@Module({
+  controllers: [ProjectsController],
+})
+export class ProjectsModule {}


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
- #4 

## 📌 개발 이유
- 프론트엔드와의 원활한 협업을 위해 API 명세서를 작성했습니다. 
- API 명세서는 Swagger의 형태로 작성했습니다. 
- 작성한 API 명세서를 사용해볼 수 있도록 Mock API를 만들었습니다. 

## 💻 수정 사항
- GET /logos API 명세서와 mock API를 작성했습니다. 
- GET /partners API 명세서와 mock API를 작성했습니다. 
- GET /cooperation-projects API 명세서와 mock API를 작성했습니다. 
- 위 3개 API는 기존 프로젝트의 response type을 그대로 가져왔으며, 기존 프로젝트의 GET /history/partners API에 Response의  projects, partners 속성을 각각 GET /partners, GET /cooperation-projects API로 분리했습니다. 
- ProjectsResponseDto를 작성하고, GET /projects/:projectId API 명세서와 mock API를 작성했습니다. 
- ProjectsListResponseDto를 작성하고, GET /projects API 명세서와 mock API를 작성했습니다. 

## 🧪 테스트 방법
- 해당 브랜치를 pull 받고 yarn run start:dev를 통해 서버를 실행시킵니다. 
- localhost:3000/api-docs로 이동해 다음과 같이 작성된 API 명세서를 확인합니다.   

![스크린샷 2022-10-11 오후 3 17 16](https://user-images.githubusercontent.com/44994031/195010951-15be5923-2e23-423d-aa75-2bb88c99b05b.png)
  
- swagger의 execute기능을 사용해 모든 API가 mockResponse를 반환하는지 확인합니다. 

## ⛳️ 고민한 점 || 궁굼한 점
- GET /projects API 명세서를 작성하면서 프로젝트 필터링 기능과 페이지네이션을 위한 Query를 고민했습니다. 
- 페이지네이션을 위해 `limit`과 `page` query를 받는 것으로 설계했습니다. 또한, ProjectsListResponseDto에 `hasMore` 속성을 추가하여 데이터의 끝을 명시해줄 수 있도록 했습니다. 
- 필터링을 위해 `filter` query를 받는 것으로 설계했습니다. 추후 다중 필터링 조건 선택을 할 경우 어떻게 설계해야할 지 고민해보는게 좋을 것 같습니다. 

## 🎯 리뷰 포인트
- 작성한 Query ( `limit`, `page`, `filter` ) 가 괜찮게 사용될 수 있을지? ProjectsListResponseDto에 `hasMore` 속성을 추가해도 될 지 봐주세요! 

## 📁 레퍼런스
https://docs.nestjs.com/openapi/types-and-parameters