### PR TITLE
chore : Codepipeline + Elasticbeanstalk을 사용한 CD 구축 

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,61 @@
+version: 0.2
+
+#env:
+#variables:
+# key: "value"
+# key: "value"
+#parameter-store:
+# key: "value"
+# key: "value"
+#secrets-manager:
+# key: secret-id:json-key:version-stage:version-id
+# key: secret-id:json-key:version-stage:version-id
+#exported-variables:
+# - variable
+# - variable
+#git-credential-helper: yes
+#batch:
+#fast-fail: true
+#build-list:
+#build-matrix:
+#build-graph:
+phases:
+  install:
+    #Ubuntu 표준 이미지 2.0 이상을 사용하는 경우 런타임 버전을 지정해야 합니다.
+    #런타임 버전을 지정하는 경우 Ubuntu 표준 이미지 2.0 이외의 이미지를 사용하면 빌드에 실패합니다.
+    #runtime-versions:
+    # name: version
+    # name: version
+    commands:
+      - npm install
+      # - command
+  #pre_build:
+  #commands:
+  # - command
+  # - command
+  build:
+    commands:
+      - yarn run build
+      # - command
+  #post_build:
+  #commands:
+  # - command
+  # - command
+#reports:
+#report-name-or-arn:
+#files:
+# - location
+# - location
+#base-directory: location
+#discard-paths: yes
+#file-format: JunitXml | CucumberJson
+artifacts:
+  files:
+    - '**/*'
+    # - location
+  #name: $(date +%Y-%m-%d)
+  discard-paths: no
+  base-directory: ./
+#cache:
+#paths:
+# - paths

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "node dist/src/main.js",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
HTTPS 적용 및 CD를 위해 Codepipeline + Elasticbeanstalk을 사용하고자 했습니다. 
build 과정에서 필요한 buildspec.yml을 추가했습니다. 
서버 시작 명령어를 수정했습니다. 

## 💻 수정 사항
npm run start 명령어의 커맨드를 node dist/src/main으로 수정 
-> build시 생성되는 dist 폴더 내에 main.js 가 src 디렉토리 안에 생기더라구요. 

buildspec.yml 파일 작성
npm install과 yarn run build 커맨드를 수행하도록 buildspec.yml 파일을 작성했습니다. 

## 🧪 테스트 방법
https://dev.dguchatbot.com/api-docs에 접속해 명세서가 노출되는지 확인합니다. 
develop branch에 merge시 수정사항이 서버에 자동으로 반영되는지 확인합니다. 

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
