### PR TITLE
feat : #12 GET /logos API 개발 

### DIFF
--- a/docs/logos/logos.swagger.ts
+++ b/docs/logos/logos.swagger.ts
@@ -7,6 +7,6 @@ export function GetLogosDocs() {
     ApiOperation({
       summary: '프로젝트 로고 조회',
     }),
-    ApiOkResponse({ type: Array<LogosResponseDto> }),
+    ApiOkResponse({ type: [LogosResponseDto] }),
   );
 }

--- a/src/logos/controllers/logos.controller.ts
+++ b/src/logos/controllers/logos.controller.ts
@@ -9,7 +9,7 @@ function getLogosResponseDto(logos: Logo[]): LogosResponseDto[] {
   return logos.map((logo: Logo) => {
     return {
       id: logo.id,
-      image: logo.image ? logo.image : '',
+      image: logo.image,
     };
   });
 }

--- a/src/logos/controllers/logos.controller.ts
+++ b/src/logos/controllers/logos.controller.ts
@@ -2,17 +2,27 @@ import { Controller, Get } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetLogosDocs } from 'docs/logos/logos.swagger';
 import { LogosResponseDto } from 'src/logos/dtos/logos-response.dto';
+import { Logo } from 'src/logos/entities/logos.entity';
+import { LogosService } from 'src/logos/services/logos.service';
+
+function getLogosResponseDto(logos: Logo[]): LogosResponseDto[] {
+  return logos.map((logo: Logo) => {
+    return {
+      id: logo.id,
+      image: logo.image ? logo.image : '',
+    };
+  });
+}
+
 @ApiTags('Logos')
 @Controller('logos')
 export class LogosController {
+  constructor(private readonly logosService: LogosService) {}
+
   @Get('')
   @GetLogosDocs()
-  async getLogos(): Promise<Array<LogosResponseDto>> {
-    const mockLogo: LogosResponseDto = {
-      id: 1,
-      image:
-        'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/logo/1660922410081_AvI196XNRbXdWXpWQKlkg.png',
-    };
-    return [mockLogo];
+  async getLogos(): Promise<LogosResponseDto[]> {
+    const logos = await this.logosService.findAll();
+    return getLogosResponseDto(logos);
   }
 }

--- a/src/logos/dtos/logos-response.dto.ts
+++ b/src/logos/dtos/logos-response.dto.ts
@@ -11,7 +11,8 @@ export class LogosResponseDto {
   @ApiProperty({
     type: String,
     required: true,
+    nullable: true,
     description: 'logo 이미지의 url 주소',
   })
-  image: string;
+  image: string | null;
 }

--- a/src/logos/entities/logos.entity.ts
+++ b/src/logos/entities/logos.entity.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Index('logo_id_uindex', ['id'], { unique: true })
+@Index('logo_pk', ['id'], { unique: true })
+@Entity('Logo', { schema: 'public' })
+export class Logo {
+  @PrimaryGeneratedColumn({ type: 'integer', name: 'id' })
+  id: number;
+
+  @Column('varchar', { name: 'image', nullable: true, length: 500 })
+  image: string | null;
+
+  @Column({ type: 'integer', name: 'semesterId', nullable: false })
+  semesterId: number;
+}

--- a/src/logos/entities/logos.entity.ts
+++ b/src/logos/entities/logos.entity.ts
@@ -4,7 +4,7 @@ import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 @Index('logo_pk', ['id'], { unique: true })
 @Entity('Logo', { schema: 'public' })
 export class Logo {
-  @PrimaryGeneratedColumn({ type: 'integer', name: 'id' })
+  @PrimaryGeneratedColumn('increment', { type: 'integer', name: 'id' })
   id: number;
 
   @Column('varchar', { name: 'image', nullable: true, length: 500 })

--- a/src/logos/logos.module.ts
+++ b/src/logos/logos.module.ts
@@ -1,7 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Logo } from 'src/logos/entities/logos.entity';
 import { LogosController } from 'src/logos/controllers/logos.controller';
+import { LogosService } from 'src/logos/services/logos.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Logo])],
+  providers: [LogosService],
   controllers: [LogosController],
 })
 export class LogosModule {}

--- a/src/logos/services/logos.service.ts
+++ b/src/logos/services/logos.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Logo } from 'src/logos/entities/logos.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class LogosService {
+  constructor(
+    @InjectRepository(Logo) private logosRepository: Repository<Logo>,
+  ) {}
+
+  findAll(): Promise<Logo[]> {
+    return this.logosRepository.find();
+  }
+}


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
- #12 

## 📌 개발 이유
sopt.org 홈 화면 로고배너에 노출되는 로고를 전달해주는 API를 개발했습니다. 

## 💻 수정 사항
- Logo Entity 작성
- Logo Service의 findAll() 메소드 개발
- GET /logos API mock Response에서 DB 데이터로 수정

## 🧪 테스트 방법
yarn run start:dev 후 swagger 상에서 GET /logos API 가 잘 동작하는지 확인. 

## ⛳️ 고민한 점 || 궁굼한 점
기존 GET /logos API는 다음과 같은 로직이 있더라구요. 
![스크린샷 2022-10-21 오후 2 24 28](https://user-images.githubusercontent.com/44994031/197118846-17743e41-3131-4644-8604-6c51039da623.png)
왜 이렇게 한지는 모르겠는데... 

그냥 모든 로고를 반환하도록 개발했습니다. 괜찮을까요? 

### 아 그리고 TypeORM을 사용해서 개발할 때 
분명 entity를 수정했는데 DB 상에 반영이 되지 않는 문제가 있었습니다. 
왜 그런고,,,, 하니 entity를 수정한 상태에서 ctrl + s를 눌러 저장을 하면 nestjs가 자동으로 재실행되는 줄 알았는데
build 파일에는 해당 저장 사항이 즉각 반영이 안되는 것 같습니다. 
build 된 dist파일을 삭제하고 다시 실행시키니까 수정한 Entity가 DB 상으로 바로 반영이 되더라구요 ( typeorm.config.ts에 synchronize : true로 했을 때 ) 
이것 때문에 왜.... 왜 안되지..? 고민 많이 했어요 😢 

## 🎯 리뷰 포인트

## 📁 레퍼런스
