### PR TITLE
feat : #13 GET /cooperation-projects API 개발 

### DIFF
--- a/docs/cooperation-projects/cooperation-projects.swagger.ts
+++ b/docs/cooperation-projects/cooperation-projects.swagger.ts
@@ -7,6 +7,6 @@ export function GetCooperationProjectsDocs() {
     ApiOperation({
       summary: '협력사와 진행한 프로젝트 조회',
     }),
-    ApiOkResponse({ type: Array<CooperationProjectsResponseDto> }),
+    ApiOkResponse({ type: [CooperationProjectsResponseDto] }),
   );
 }

--- a/src/cooperation-projects/controllers/cooperation-projects.controller.ts
+++ b/src/cooperation-projects/controllers/cooperation-projects.controller.ts
@@ -2,24 +2,40 @@ import { Controller, Get } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetCooperationProjectsDocs } from 'docs/cooperation-projects/cooperation-projects.swagger';
 import { CooperationProjectsResponseDto } from 'src/cooperation-projects/dtos/cooperation-projects-response.dto';
+import { CooperationProject } from 'src/cooperation-projects/entities/cooperation-projects.entity';
+import { CooperationProjectsService } from 'src/cooperation-projects/services/cooperation-projects.service';
+
+function getCooperationProjectsResponseDto(
+  cooperationProjects: CooperationProject[],
+): CooperationProjectsResponseDto[] {
+  return cooperationProjects.map((cooperationProject: CooperationProject) => {
+    return {
+      id: cooperationProject.id,
+      year: cooperationProject.year ? cooperationProject.year : 0,
+      title: cooperationProject.title ? cooperationProject.title : '',
+      content: cooperationProject.content ? cooperationProject.content : '',
+      subContent: cooperationProject.subContent
+        ? cooperationProject.subContent
+        : '',
+      posterImage: cooperationProject.posterImage
+        ? cooperationProject.posterImage
+        : '',
+    };
+  });
+}
 
 @ApiTags('CooperationProject')
 @Controller('cooperation-projects')
 export class CooperationProjectsController {
+  constructor(
+    private readonly cooperationProjectsService: CooperationProjectsService,
+  ) {}
   @Get()
   @GetCooperationProjectsDocs()
   async getCooperationProjects(): Promise<
     Array<CooperationProjectsResponseDto>
   > {
-    const mockCooperationProject: CooperationProjectsResponseDto = {
-      id: 11,
-      year: 2022,
-      title: 'KB D.N.A 프로젝트',
-      content: `KB금융그룹과 SOPT, 디지털 전문가가 협업하여 KB 디지털 프로젝트의 개선과제를 발굴하고, 이를 해결하기 위한 구체적인 아이디어를 도출해 프로토타입을 제작하는 프로젝트`,
-      subContent: '2018년부터 총 5회 진행',
-      posterImage:
-        'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/partners/poster/1661005789051_chHEt5ezSXlTRKfHmRnRv.png',
-    };
-    return [mockCooperationProject];
+    const cooperationProjects = await this.cooperationProjectsService.findAll();
+    return getCooperationProjectsResponseDto(cooperationProjects);
   }
 }

--- a/src/cooperation-projects/controllers/cooperation-projects.controller.ts
+++ b/src/cooperation-projects/controllers/cooperation-projects.controller.ts
@@ -11,15 +11,11 @@ function getCooperationProjectsResponseDto(
   return cooperationProjects.map((cooperationProject: CooperationProject) => {
     return {
       id: cooperationProject.id,
-      year: cooperationProject.year ? cooperationProject.year : 0,
-      title: cooperationProject.title ? cooperationProject.title : '',
-      content: cooperationProject.content ? cooperationProject.content : '',
-      subContent: cooperationProject.subContent
-        ? cooperationProject.subContent
-        : '',
-      posterImage: cooperationProject.posterImage
-        ? cooperationProject.posterImage
-        : '',
+      year: cooperationProject.year,
+      title: cooperationProject.title,
+      content: cooperationProject.content,
+      subContent: cooperationProject.subContent,
+      posterImage: cooperationProject.posterImage,
     };
   });
 }
@@ -36,6 +32,7 @@ export class CooperationProjectsController {
     Array<CooperationProjectsResponseDto>
   > {
     const cooperationProjects = await this.cooperationProjectsService.findAll();
+    console.log(cooperationProjects);
     return getCooperationProjectsResponseDto(cooperationProjects);
   }
 }

--- a/src/cooperation-projects/controllers/cooperation-projects.controller.ts
+++ b/src/cooperation-projects/controllers/cooperation-projects.controller.ts
@@ -32,7 +32,6 @@ export class CooperationProjectsController {
     Array<CooperationProjectsResponseDto>
   > {
     const cooperationProjects = await this.cooperationProjectsService.findAll();
-    console.log(cooperationProjects);
     return getCooperationProjectsResponseDto(cooperationProjects);
   }
 }

--- a/src/cooperation-projects/cooperation-projects.module.ts
+++ b/src/cooperation-projects/cooperation-projects.module.ts
@@ -1,7 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CooperationProject } from 'src/cooperation-projects/entities/cooperation-projects.entity';
+import { CooperationProjectsService } from 'src/cooperation-projects/services/cooperation-projects.service';
 import { CooperationProjectsController } from './controllers/cooperation-projects.controller';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([CooperationProject])],
+  providers: [CooperationProjectsService],
   controllers: [CooperationProjectsController],
 })
 export class CooperationProjectsModule {}

--- a/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
+++ b/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
@@ -31,7 +31,7 @@ export class CooperationProjectsResponseDto {
 
   @ApiProperty({
     type: String,
-    required: false,
+    required: true,
     description: '프로젝트에 대한 추가 정보',
   })
   subContent?: string;

--- a/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
+++ b/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
@@ -13,33 +13,33 @@ export class CooperationProjectsResponseDto {
     required: true,
     description: '프로젝트를 진행한 연도',
   })
-  year: number;
+  year: number | null;
 
   @ApiProperty({
     type: String,
     required: true,
     description: '프로젝트의 이름',
   })
-  title: string;
+  title: string | null;
 
   @ApiProperty({
     type: String,
     required: true,
     description: '프로젝트에 대한 설명',
   })
-  content: string;
+  content: string | null;
 
   @ApiProperty({
     type: String,
     required: true,
     description: '프로젝트에 대한 추가 정보',
   })
-  subContent?: string;
+  subContent?: string | null;
 
   @ApiProperty({
     type: String,
     required: true,
     description: '협력사와 진행한 프로젝트의 포스터 이미지',
   })
-  posterImage: string;
+  posterImage: string | null;
 }

--- a/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
+++ b/src/cooperation-projects/dtos/cooperation-projects-response.dto.ts
@@ -12,6 +12,7 @@ export class CooperationProjectsResponseDto {
     type: Number,
     required: true,
     description: '프로젝트를 진행한 연도',
+    nullable: true,
   })
   year: number | null;
 
@@ -19,6 +20,7 @@ export class CooperationProjectsResponseDto {
     type: String,
     required: true,
     description: '프로젝트의 이름',
+    nullable: true,
   })
   title: string | null;
 
@@ -26,6 +28,7 @@ export class CooperationProjectsResponseDto {
     type: String,
     required: true,
     description: '프로젝트에 대한 설명',
+    nullable: true,
   })
   content: string | null;
 
@@ -33,6 +36,7 @@ export class CooperationProjectsResponseDto {
     type: String,
     required: true,
     description: '프로젝트에 대한 추가 정보',
+    nullable: true,
   })
   subContent?: string | null;
 
@@ -40,6 +44,7 @@ export class CooperationProjectsResponseDto {
     type: String,
     required: true,
     description: '협력사와 진행한 프로젝트의 포스터 이미지',
+    nullable: true,
   })
   posterImage: string | null;
 }

--- a/src/cooperation-projects/entities/cooperation-projects.entity.ts
+++ b/src/cooperation-projects/entities/cooperation-projects.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Index('cooperation_project_pk', ['id'], { unique: true })
+@Index('cooperation_project_id_uindex', ['id'], { unique: true })
+@Entity('CooperationProject', { schema: 'public' })
+export class CooperationProject {
+  @PrimaryGeneratedColumn({ type: 'integer', name: 'id' })
+  id: number;
+
+  @Column('integer', { name: 'year', nullable: true })
+  year?: number | null;
+
+  @Column('varchar', { name: 'title', nullable: true, length: 50 })
+  title?: string | null;
+
+  @Column('varchar', { name: 'content', nullable: true, length: 300 })
+  content?: string | null;
+
+  @Column('varchar', {
+    name: 'subContent',
+    nullable: true,
+    length: 300,
+  })
+  subContent?: string | null;
+
+  @Column('varchar', {
+    name: 'posterImage',
+    nullable: true,
+    length: 500,
+  })
+  posterImage?: string | null;
+}

--- a/src/cooperation-projects/entities/cooperation-projects.entity.ts
+++ b/src/cooperation-projects/entities/cooperation-projects.entity.ts
@@ -8,25 +8,25 @@ export class CooperationProject {
   id: number;
 
   @Column('integer', { name: 'year', nullable: true })
-  year?: number | null;
+  year: number | null;
 
   @Column('varchar', { name: 'title', nullable: true, length: 50 })
-  title?: string | null;
+  title: string | null;
 
   @Column('varchar', { name: 'content', nullable: true, length: 300 })
-  content?: string | null;
+  content: string | null;
 
   @Column('varchar', {
     name: 'subContent',
     nullable: true,
     length: 300,
   })
-  subContent?: string | null;
+  subContent: string | null;
 
   @Column('varchar', {
     name: 'posterImage',
     nullable: true,
     length: 500,
   })
-  posterImage?: string | null;
+  posterImage: string | null;
 }

--- a/src/cooperation-projects/services/cooperation-projects.service.ts
+++ b/src/cooperation-projects/services/cooperation-projects.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CooperationProject } from 'src/cooperation-projects/entities/cooperation-projects.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CooperationProjectsService {
+  constructor(
+    @InjectRepository(CooperationProject)
+    private cooperationProjectsRepository: Repository<CooperationProject>,
+  ) {}
+
+  findAll(): Promise<CooperationProject[]> {
+    return this.cooperationProjectsRepository.find();
+  }
+}

--- a/src/cooperation-projects/services/cooperation-projects.service.ts
+++ b/src/cooperation-projects/services/cooperation-projects.service.ts
@@ -11,6 +11,6 @@ export class CooperationProjectsService {
   ) {}
 
   findAll(): Promise<CooperationProject[]> {
-    return this.cooperationProjectsRepository.find();
+    return this.cooperationProjectsRepository.find({ order: { year: 'DESC' } });
   }
 }


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
- #13 

## 📌 개발 이유
파트너와 협력한 프로젝트를 노출시키기 위한 API 개발 

## 💻 수정 사항
- CooperationProject Entity 생성
- CooperationProject findAll() API 개발 
- GET /cooperation-projects API 개발 
- DB에 CooperationProject Table 생성 및 데이터 추가 

## 🧪 테스트 방법
yarn run start:dev로 서버 시작
GET /cooperation-projects API 호출하여 협력사 프로젝트들을 잘 가져오는지 확인 

## ⛳️ 고민한 점 || 궁굼한 점
entity 수준에서 optional하게 값이 오지 않을 것 같아서 CooperationProject entity의 속성들의 optional을 전부 제거했습니다. 
DB에 subContent 들이 빈 문자열로 저장되어 있어 null이 아니라 빈 문자열로 전달이 되어 기존 API와 차이가 생겨요 

- 기존 
![스크린샷 2022-10-22 오후 11 21 47](https://user-images.githubusercontent.com/44994031/197344266-4e02cf39-8ec6-49fe-8d03-71570a155438.png)

- 현재 
![스크린샷 2022-10-22 오후 11 23 07](https://user-images.githubusercontent.com/44994031/197344349-b6d413c6-47a6-45b7-921e-e76b544430fd.png)
subContent가 기존에는 null, 현재는 ""으로 되는데 다음과 같은 방법으로 수정할 수 있을 것 같습니다. 

1. 프론트엔드에 물어보고 null이든 ""이든 상관 없으면 현상 유지 
2. null이여야만 할 경우 DB에 subContent 값을 null로 변경
3. null이여야만 할 경우 controller에 빈 문자열을 null로 바꿔주는 코드 작성

1번 아니면 2번이 괜찮을 것 같은데 어떻게 생각하시나용? 

## 🎯 리뷰 포인트

## 📁 레퍼런스
