### PR TITLE
docs : #14 projects 관련 API 수정

### DIFF
--- a/docs/projects/projects.swagger.ts
+++ b/docs/projects/projects.swagger.ts
@@ -25,12 +25,6 @@ export function GetProjectsDocs() {
       required: true,
       description: '가져올 페이지 수',
     }),
-    ApiQuery({
-      name: 'filter',
-      type: String,
-      required: false,
-      description: '필터 유형. 추후 다중 필터 설정 가능 예정',
-    }),
     ApiOkResponse({ type: ProjectsListResponseDto }),
   );
 }

--- a/docs/projects/projects.swagger.ts
+++ b/docs/projects/projects.swagger.ts
@@ -16,13 +16,13 @@ export function GetProjectsDocs() {
     ApiQuery({
       name: 'limit',
       type: Number,
-      required: true,
+      required: false,
       description: '한번에 가져올 데이터',
     }),
     ApiQuery({
       name: 'page',
       type: Number,
-      required: true,
+      required: false,
       description: '가져올 페이지 수',
     }),
     ApiOkResponse({ type: ProjectsListResponseDto }),

--- a/src/projects/controllers/projects.controller.ts
+++ b/src/projects/controllers/projects.controller.ts
@@ -4,8 +4,12 @@ import {
   GetProjectDocs,
   GetProjectsDocs,
 } from 'docs/projects/projects.swagger';
+import { ProjectType } from 'src/projects/dtos/category';
 import { ProjectsListResponseDto } from 'src/projects/dtos/projects-list-response.dto';
-import { ProjectsResponseDto } from 'src/projects/dtos/projects-response.dto';
+import {
+  ProjectsResponseDto,
+  ServiceType,
+} from 'src/projects/dtos/projects-response.dto';
 
 @ApiTags('Project')
 @Controller('projects')
@@ -13,44 +17,46 @@ export class ProjectsController {
   mockProjectsResponseDto: ProjectsResponseDto = {
     id: 1,
     name: '테스트 프로젝트',
-    semester: 30,
-    isProvidingService: true,
-    isBusinessing: false,
-    teamMembers: [
+    generation: 30,
+    isAvailable: true,
+    isFounding: false,
+    members: [
       {
         name: '이정연',
         role: 'Project Manager',
-        roleDetail:
+        description:
           'API 명세서 작성 및 서버 구축 및 AI 설계 근데 이제 엄청 엄청 긴 세줄을 만들기 위해 추가 설명을 곁들인 ',
       },
       {
         name: '정예린',
         role: 'Project Designer',
-        roleDetail: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
-      },
-    ],
-    afterJoinedTeamMembers: [
-      {
-        name: '정예린',
-        role: 'Project Designer',
-        roleDetail: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
+        description: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
       },
       {
         name: '정예린',
         role: 'Project Designer',
-        roleDetail: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
+        description: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
+      },
+      {
+        name: '정예린',
+        role: 'Project Designer',
+        description: 'UXUI 디자인 및 브랜딩 전반을 제작, 그래픽 일러스트 제작',
       },
     ],
-    serviceType: ['WEB', 'APP'],
-    startDate: new Date(),
-    endDate: new Date(),
-    inProgress: false,
-    shortIntroduction: '테스트 프로젝트입니다.',
+    serviceType: [ServiceType.WEB, ServiceType.APP],
+    startAt: new Date(),
+    endAt: new Date(),
+    summary: '테스트 프로젝트입니다.',
     detail:
       '테스트프로젝트는 영국에서 시작되어 8년이 지나 대한민국으로 들어왔습니다. 이 편지를 본 당신은 행운이 가득하고 모든일이 잘 될겁니다.',
-    logoImageUrl:
+    logoImage:
       'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/logo/1660922410081_AvI196XNRbXdWXpWQKlkg.png',
-    link: [{ type: 'github', url: 'https://github.com/TAKE-US/TAKEUS-BACK' }],
+    link: [{ title: 'github', url: 'https://github.com/TAKE-US/TAKEUS-BACK' }],
+    category: { project: ProjectType.APPJAM },
+    thumbnailImage: null,
+    projectImage: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   };
 
   @Get('')

--- a/src/projects/controllers/projects.controller.ts
+++ b/src/projects/controllers/projects.controller.ts
@@ -55,7 +55,7 @@ export class ProjectsController {
     category: { project: ProjectType.APPJAM },
     thumbnailImage: null,
     projectImage: null,
-    createdAt: new Date(),
+    uploadedAt: new Date(),
     updatedAt: new Date(),
   };
 

--- a/src/projects/dtos/category.ts
+++ b/src/projects/dtos/category.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum ProjectType {
+  APPJAM = 'APPJAM',
+  SOPKATHON = 'SOPKATHON',
+  SOPTERM = 'SOPTERM',
+  STUDY = 'STUDY',
+  JOINTSEMINAR = 'JOINTSEMINAR',
+  ETC = 'ETC',
+}
+
+export class Category {
+  @ApiProperty({
+    enum: ProjectType,
+    required: true,
+  })
+  project: ProjectType;
+}

--- a/src/projects/dtos/link.ts
+++ b/src/projects/dtos/link.ts
@@ -7,7 +7,7 @@ export class Link {
     description:
       '웹사이트, 구글 플레이스토어, 앱스토어, Github, 발표영상 등 프로젝트에 관련된 링크의 종류',
   })
-  type: string;
+  title: string;
 
   @ApiProperty({
     type: String,

--- a/src/projects/dtos/member.ts
+++ b/src/projects/dtos/member.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class ProjectsTeamMember {
+export class Member {
   @ApiProperty({
     type: String,
     required: true,
@@ -20,5 +20,5 @@ export class ProjectsTeamMember {
     required: true,
     description: '프로젝트 팀원의 역할 상세설명',
   })
-  roleDetail: string;
+  description: string;
 }

--- a/src/projects/dtos/projects-list-response.dto.ts
+++ b/src/projects/dtos/projects-list-response.dto.ts
@@ -3,7 +3,7 @@ import { ProjectsResponseDto } from 'src/projects/dtos/projects-response.dto';
 
 export class ProjectsListResponseDto {
   @ApiProperty({
-    type: Array<ProjectsResponseDto>,
+    type: [ProjectsResponseDto],
     required: true,
   })
   projects: Array<ProjectsResponseDto>;

--- a/src/projects/dtos/projects-response.dto.ts
+++ b/src/projects/dtos/projects-response.dto.ts
@@ -117,7 +117,7 @@ export class ProjectsResponseDto {
     required: true,
     description: '프로젝트를 등록한 시간',
   })
-  createdAt: Date;
+  uploadedAt: Date;
 
   @ApiProperty({
     type: Date,

--- a/src/projects/dtos/projects-response.dto.ts
+++ b/src/projects/dtos/projects-response.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Link } from 'src/projects/dtos/link';
-import { ProjectsTeamMember } from 'src/projects/dtos/projects-team-member';
+import { Member } from 'src/projects/dtos/member';
+import { Category } from 'src/projects/dtos/category';
+
+export enum ServiceType {
+  WEB = 'WEB',
+  APP = 'APP',
+}
 
 export class ProjectsResponseDto {
   @ApiProperty({
@@ -22,70 +28,59 @@ export class ProjectsResponseDto {
     required: true,
     description: '프로젝트가 진행된 기수',
   })
-  semester: number;
+  generation: number;
 
   @ApiProperty({
-    type: Boolean,
+    type: Category,
     required: true,
-    description: '프로젝트의 서비스 진행 여부',
+    description: '프로젝트의 카테고리',
   })
-  isProvidingService: boolean;
-
-  @ApiProperty({
-    type: Boolean,
-    required: true,
-    description: '프로젝트의 창업 여부',
-  })
-  isBusinessing: boolean;
-
-  @ApiProperty({
-    type: Array<ProjectsTeamMember>,
-    required: false,
-    description: '프로젝트의 팀원',
-  })
-  teamMembers?: Array<ProjectsTeamMember>;
-
-  @ApiProperty({
-    type: Array<ProjectsTeamMember>,
-    required: false,
-    description: '추가 합류한 팀원',
-  })
-  afterJoinedTeamMembers?: Array<ProjectsTeamMember>;
-
-  @ApiProperty({
-    type: Array<string>,
-    required: true,
-    description: '서비스 형태',
-  })
-  serviceType: Array<string>;
+  category: Category;
 
   @ApiProperty({
     type: Date,
     required: true,
     description: '프로젝트 시작 날짜',
   })
-  startDate: Date;
+  startAt: Date;
 
   @ApiProperty({
     type: Date,
     required: false,
+    nullable: true,
     description: '프로젝트 종료 날짜. 프로젝트가 진행중 일 경우 값 없음',
   })
-  endDate?: Date;
+  endAt?: Date;
+
+  @ApiProperty({
+    enum: ServiceType,
+    required: true,
+    isArray: true,
+    example: [ServiceType.APP, ServiceType.WEB],
+    description: '서비스 형태',
+  })
+  serviceType: Array<ServiceType>;
 
   @ApiProperty({
     type: Boolean,
     required: true,
-    description: '프로젝트의 진행중 여부',
+    description: '프로젝트의 서비스 진행 여부',
   })
-  inProgress: boolean;
+  isAvailable: boolean;
+
+  @ApiProperty({
+    type: Boolean,
+    required: true,
+    description: '프로젝트의 창업 여부',
+  })
+  isFounding: boolean;
 
   @ApiProperty({
     type: String,
     required: true,
     description: '프로젝트 한줄소개',
   })
-  shortIntroduction: string;
+  summary: string;
 
   @ApiProperty({
     type: String,
@@ -99,26 +94,49 @@ export class ProjectsResponseDto {
     required: true,
     description: '프로젝트 로고 이미지 URL',
   })
-  logoImageUrl: string;
-
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: '프로젝트 썸네일 이미지 URL',
-  })
-  thumbnailImageUrl?: string;
+  logoImage: string;
 
   @ApiProperty({
     type: String,
     required: true,
-    description: '프로젝트 이미지 URL',
+    nullable: true,
+    description: '프로젝트 썸네일 이미지 URL',
   })
-  projectImageUrl?: string;
+  thumbnailImage: string | null;
 
   @ApiProperty({
-    type: Array<Link>,
+    type: String,
+    required: true,
+    nullable: true,
+    description: '프로젝트 이미지 URL',
+  })
+  projectImage: string | null;
+
+  @ApiProperty({
+    type: Date,
+    required: true,
+    description: '프로젝트를 등록한 시간',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    type: Date,
+    required: true,
+    description: '프로젝트를 수정한 시간',
+  })
+  updatedAt: Date;
+
+  @ApiProperty({
+    type: [Link],
     required: true,
     description: '프로젝트 링크',
   })
-  link?: Array<Link>;
+  link: Array<Link>;
+
+  @ApiProperty({
+    type: [Member],
+    required: true,
+    description: '프로젝트 팀원',
+  })
+  members: Array<Member>;
 }


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
- #14 

## 📌 개발 이유
공식 홈페이지 팀 신규 개발인 projects를 보여주는 페이지에 대한 API 명세서 작성 

## 💻 수정 사항
### 속성 수정 사항. 
1. ProjectsResponseDto의 많은 속성들의 이름과 속성이 변경되었습니다. 
- ProjectsResponseDto
  - semester => generation으로 rename
  - startDate => startAt으로 rename
  - endDate => endAt으로 rename
  - isProvidingService => isAvailable으로 rename
  - isBusinessing => isFounding으로 rename 
  - shortIntroduction => summary으로 rename
  - logoImageUrl => logoImage으로 rename 
  - thumbnailImageUrl => thumbnailImage으로 rename, optional 제거, nullable = true로 변경 
  - projectImageUrl => projectImage으로 rename, optional 제거, nullable = true로 변경 
  - link => optional 제거, link.type => link.title로 변경 
 
2. teamMembers, afterJoinedTeamMembers 속성 삭제
3. members 속성 신규 추가 
![스크린샷 2022-10-27 오전 2 09 03](https://user-images.githubusercontent.com/44994031/198091564-5f46f11d-15d3-4095-ac4e-e724d68d7ce7.png)
4. createdAt, updatedAt 속성 신규 추가 
![스크린샷 2022-10-27 오전 2 16 44](https://user-images.githubusercontent.com/44994031/198093041-0ef9d8b9-8f50-4d59-bf7c-d8b1445068ae.png)
5. category 속성 신규 추가 
![스크린샷 2022-10-27 오전 2 13 09](https://user-images.githubusercontent.com/44994031/198092376-d8ed4206-9bd7-40cf-9a82-a784f4639777.png)


### GET /projects API에서 query의 filter 삭제. 
필터 기능을 프론트엔드에서 진행하여 filter 쿼리 삭제. 


## 🧪 테스트 방법
yarn run start:dev를 통해 서버를 실행시킨 뒤 localhost:3000/api-docs 접속
GET /projects API와 GET /projects/:projectId에 변경된 ProjectsResponseDto의 반영사항 확인
execute를 통해 mockResponse가 잘 오는지 확인 

## ⛳️ 고민한 점 || 궁굼한 점
- 궁굼한 점 
  - filter기능을 프론트엔드로 이전함에 따라서 filter query를 수정했는데 filter 기능을 수행하려면 모든 projects에 대한 정보를 한번에 넘겨줘야 하지 않을까 생각이 듭니다. 그에 따라서 페이지네이션 기능도 삭제가 되어야할 것 같은데 어떻게 생각하시나요? 
@Jeong-Hyowon @ingong @leeseooo 

## 🎯 리뷰 포인트

## 📁 레퍼런스
