### PR TITLE
docs : #14 LinkType Enum API 문서 수정

### DIFF
--- a/src/projects/dtos/link.ts
+++ b/src/projects/dtos/link.ts
@@ -1,13 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export enum LinkType {
-  WEBSITE = '웹사이트',
-  GOOGLE_PLAYSTORE = '구글 플레이스토어',
-  APP_STORE = '앱 스토어',
-  GITHUB = 'Github',
-  PRESENTATION_VIDEO = '발표영상',
+  WEBSITE = 'website',
+  GOOGLE_PLAYSTORE = 'googlePlay',
+  APP_STORE = 'appStore',
+  GITHUB = 'github',
+  MEDIA = 'media',
   INSTAGRAM = 'instagram',
-  ETC = '기타 관련자료',
 }
 
 export class Link {


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
- #14 
## 📌 개발 이유
플레이그라운드 팀으로부터 가져온 프로젝트 데이터에서 LinkType에 대한 enum값이 
공홈팀에서 설정한 값과 플레이그라운드 팀에서 설정한 값이 달라 수정합니다. 

## 💻 수정 사항
LinkType Enum을 수정했습니다. 

## 🧪 테스트 방법
API 문서에 다음과 같이 링크타입이 
website, googlePlay, appStore, media, instagram, github 으로 구성되는지 확인합니다. 
<img width="698" alt="스크린샷 2022-11-25 오후 7 09 07" src="https://user-images.githubusercontent.com/44994031/203957808-58cf099e-bf2c-44ab-83af-0cccd569fad4.png">

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트
@leeseooo @ingong 
## 📁 레퍼런스
