### PR TITLE
feat : #15 GET /semesters API 개발 

### DIFF
--- a/src/semesters/controllers/semesters.controller.ts
+++ b/src/semesters/controllers/semesters.controller.ts
@@ -1,29 +1,36 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetSemestersDocs } from 'docs/semesters/semesters.swagger';
+import { SemestersInfoResponseDto } from 'src/semesters/dtos/semesters-info-response.dto';
 import { SemestersListResponseDto } from 'src/semesters/dtos/semesters-list-response.dto';
+import { Semester } from 'src/semesters/entities/semesters.entity';
+import { SemestersService } from 'src/semesters/services/semesters.service';
 
 @Controller('semesters')
 @ApiTags('Semester')
 export class SemestersController {
+  constructor(private readonly semestersService: SemestersService) {}
+
   @Get('')
   @GetSemestersDocs()
-  async getSemesters(): Promise<SemestersListResponseDto> {
-    const mockSemester: SemestersListResponseDto = {
-      page: 0,
-      limit: 0,
-      total: 1,
-      semesters: [
-        {
-          id: 1,
-          color: null, //'#4877AF'
-          logo: 'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/semester/logo/default.png',
-          background: null, // 'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/semester/background/time_31.png',
-          name: null, //'IN',
-          year: '2007 하반기',
-        },
-      ],
+  async getSemesters(
+    @Query('limit', ParseIntPipe) limit: number,
+    @Query('page', ParseIntPipe) page: number,
+  ): Promise<SemestersListResponseDto> {
+    const semesters = await this.semestersService.findAll(limit, page);
+    const count = await this.semestersService.count();
+
+    const semestersInfoList: SemestersInfoResponseDto[] = semesters.map(
+      (semester: Semester) => {
+        return new SemestersInfoResponseDto(semester);
+      },
+    );
+
+    return {
+      page: page,
+      limit: limit,
+      total: count,
+      semesters: semestersInfoList,
     };
-    return mockSemester;
   }
 }

--- a/src/semesters/dtos/semesters-info-response.dto.ts
+++ b/src/semesters/dtos/semesters-info-response.dto.ts
@@ -1,4 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Semester } from 'src/semesters/entities/semesters.entity';
+import { formatSemesterYear } from 'src/semesters/utils/formatter';
+import { DEFAULT_SEMESTER_LOGO } from 'src/utils/constants';
 
 export class SemestersInfoResponseDto {
   @ApiProperty({
@@ -42,4 +45,13 @@ export class SemestersInfoResponseDto {
     description: '기수 활동 기간',
   })
   year: string;
+
+  constructor(semester: Semester) {
+    this.id = semester.id;
+    this.color = semester.color;
+    this.logo = semester.logo ? semester.logo : DEFAULT_SEMESTER_LOGO;
+    this.background = semester.background;
+    this.name = semester.name;
+    this.year = formatSemesterYear(semester.year);
+  }
 }

--- a/src/semesters/entities/semesters.entity.ts
+++ b/src/semesters/entities/semesters.entity.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_SEMESTER_LOGO } from 'src/utils/constants';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Index('semester_pk', ['id'], { unique: true })
+@Index('semester_id_uindex', ['id'], { unique: true })
+@Entity('Semester', { schema: 'public' })
+export class Semester {
+  @PrimaryGeneratedColumn({ type: 'integer', name: 'id' })
+  id: number;
+
+  @Column('text', { name: 'history', nullable: true })
+  history: string | null;
+
+  @Column('character varying', { name: 'color', nullable: true, length: 7 })
+  color: string | null;
+
+  @Column('text', {
+    name: 'logo',
+    nullable: true,
+    default: () => DEFAULT_SEMESTER_LOGO,
+  })
+  logo: string | null;
+
+  @Column('text', { name: 'background', nullable: true })
+  background: string | null;
+
+  @Column('character varying', { name: 'name', nullable: true, length: 30 })
+  name: string | null;
+
+  @Column('character varying', { name: 'year', length: 10 })
+  year: string;
+
+  @Column('character varying', {
+    name: 'coreValue',
+    nullable: true,
+    length: 100,
+  })
+  coreValue: string | null;
+
+  @Column('text', { name: 'coreImage', nullable: true })
+  coreImage: string | null;
+}

--- a/src/semesters/semesters.module.ts
+++ b/src/semesters/semesters.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
 import { SemestersController } from './controllers/semesters.controller';
 import { SemestersDetailController } from './controllers/semesters-detail.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SemestersService } from 'src/semesters/services/semesters.service';
+import { Semester } from 'src/semesters/entities/semesters.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Semester])],
+  providers: [SemestersService],
   controllers: [SemestersController, SemestersDetailController],
 })
 export class SemestersModule {}

--- a/src/semesters/services/semesters.service.ts
+++ b/src/semesters/services/semesters.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Semester } from 'src/semesters/entities/semesters.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class SemestersService {
+  constructor(
+    @InjectRepository(Semester)
+    private semestersRepository: Repository<Semester>,
+  ) {}
+
+  async findAll(limit: number, page: number): Promise<Semester[]> {
+    const skip = limit * (page - 1);
+    const semesters = await this.semestersRepository.find({
+      order: { id: 'DESC' },
+      skip: skip,
+      take: limit,
+    });
+
+    return semesters;
+  }
+
+  async count(): Promise<number> {
+    return await this.semestersRepository.count();
+  }
+}

--- a/src/semesters/utils/formatter.ts
+++ b/src/semesters/utils/formatter.ts
@@ -1,0 +1,4 @@
+export const formatSemesterYear = (value: string) => {
+  const [year, semester] = value.split('-');
+  return semester === '1' ? `${year} 상반기` : `${year} 하반기`;
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,3 +8,6 @@ export const env = {
   development: 'development',
   local: 'local',
 };
+
+export const DEFAULT_SEMESTER_LOGO =
+  'https://sopt-makers.s3.ap-northeast-2.amazonaws.com/mainpage/semester/logo/default.png';


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
- #15 

## 📌 개발 이유
https://sopt.org/history에 사용되는 API를 migration 했습니다. 

## 💻 수정 사항
semester.entity.ts를 생성했습니다. 
semesters controller, service를 구현했습니다. 

## 🧪 테스트 방법
yarn run start:dev 로 서버 실행 후 
localhost:3000/api-docs로 이동해
GET /semester API를 호출하고 response type을 확인합니다. 

## ⛳️ 고민한 점 || 궁굼한 점
Response에 총 갯수인 total을 넘겨줘야하는데 
해당 total 정보를 가져오기 위해서 service에 count() 함수를 만들었어요.
좀 더 좋은 방식은 없을까용...?

## 🎯 리뷰 포인트
- formatter 관련 
데이터베이스에는 `2022-1` 처럼 저장이 되어있는데   
  ![스크린샷 2022-11-26 오전 1 08 46](https://user-images.githubusercontent.com/44994031/204022574-13f7e501-a2d5-476a-ab98-31774d4d2829.png)  
홈페이지 상에는 `2022 하반기`와 같은 형식으로 노출이 되더라구용.   
![image](https://user-images.githubusercontent.com/44994031/204022418-195cb105-9775-4fb4-bc1b-116ac319c9a8.png)
fommatter를 만들었는데 해당 파일의 위치(semesters/utils/formatter)나 파일 이름이 적절한지 봐주세요!   

## 📁 레퍼런스
