### PR TITLE
hotfix : #14 중복 제거 로직 추가

### DIFF
--- a/src/projects/services/projects.service.ts
+++ b/src/projects/services/projects.service.ts
@@ -12,6 +12,7 @@ import { Member } from 'src/projects/dtos/member';
 import { catchError, lastValueFrom, map } from 'rxjs';
 import { ConfigService } from '@nestjs/config';
 import { env } from 'src/utils/constants';
+import { dropDuplication } from 'src/utils/helper';
 
 @Injectable()
 export class projectsService {
@@ -109,11 +110,21 @@ export class projectsService {
         .pipe(map((res) => res.data)),
     );
 
-    if (!response) {
+    // 중복제거 로직 : 추후 제거 예정
+    const uniqueResponse: PlaygroundProjectResponseDto[] = dropDuplication(
+      response,
+      'name',
+    );
+    uniqueResponse.forEach((response) => {
+      response.links = dropDuplication(response.links, 'linkId');
+      response.members = dropDuplication(response.members, 'memberId');
+    });
+
+    if (!uniqueResponse) {
       return [];
     }
 
-    for (const data of response) {
+    for (const data of uniqueResponse) {
       res.push(this.getProjectResponseDto(data));
     }
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,0 +1,13 @@
+export function dropDuplication<T, O extends keyof T>(array: T[], property: O) {
+  const uniqueArray: T[] = [];
+  for (const element of array) {
+    const isExist = uniqueArray.find((ele) => {
+      return ele[property] == element[property];
+    });
+
+    if (!isExist) {
+      uniqueArray.push(element);
+    }
+  }
+  return uniqueArray;
+}


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
플레이그라운드 팀의 API를 통해 받아온 정보에 중복이 포함되어 있어 중복을 제거하는 로직을 추가합니다. 
해당 로직은 플레이그라운드 팀의 API가 수정되면 제거되어도 좋을 것 같습니다. 

## 💻 수정 사항
dropDuplication 함수를 추가했습니다. 
projects, links, members에 대해 해당 중복 제거를 실행했습니다. 

## 🧪 테스트 방법
GET /projects API를 호출해 links, members 속성이 중복되는지 확인합니다.
또한, 중복된 프로젝트가 전달되는지 확인합니다.
중복이 제거된 상태로 response가 전달되어야 합니다. 

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
