### PR TITLE
Refactor/study

### DIFF
--- a/src/aboutsopt/dtos/get-about-sopt-response.dto.ts
+++ b/src/aboutsopt/dtos/get-about-sopt-response.dto.ts
@@ -18,10 +18,10 @@ export class ActivitiesRecords {
 
   @ApiProperty({
     type: Number,
-    nullable: false,
-    description: '스터디 수',
+    nullable: true,
+    description: '스터디 수, CrewAPI 서버 에러시 Count대신 null을 반환합니다.',
   })
-  readonly studyCounts: number;
+  readonly studyCounts: number | null;
 }
 
 export class GetAboutSoptResponseDto {

--- a/src/aboutsopt/services/aboutsopt.service.ts
+++ b/src/aboutsopt/services/aboutsopt.service.ts
@@ -52,14 +52,14 @@ export class AboutSoptService {
 
     const members = await this.memberService.findAll({ generation });
     const projects = await this.projectService.findByGeneration(generation);
-    const studies = await this.studyService.findByGeneration(generation);
+    const studyCount = await this.studyService.getStudyCount();
 
     return {
       aboutSopt: aboutSopt,
       activitiesRecords: {
         activitiesMemberCount: members.numberOfMembersAtGeneration,
         projectCounts: projects.length,
-        studyCounts: studies.length,
+        studyCounts: studyCount,
       },
     };
   }

--- a/src/common/cache/cache.module.ts
+++ b/src/common/cache/cache.module.ts
@@ -90,6 +90,7 @@ export class CacheModule implements OnModuleInit {
         const cached = await this.cacheManager.get(cacheKey);
 
         if (Boolean(cached)) {
+          console.log('cache hit');
           return cached;
         }
 

--- a/src/common/type.ts
+++ b/src/common/type.ts
@@ -1,0 +1,8 @@
+export class CrewPageApiMetaResponseDto {
+  readonly page: number;
+  readonly take: number;
+  readonly itemCount: number;
+  readonly pageCount: number;
+  readonly hasNextPage: boolean;
+  readonly hasPreviousPage: boolean;
+}

--- a/src/study/controller/study.controller.ts
+++ b/src/study/controller/study.controller.ts
@@ -10,6 +10,6 @@ export class StudyController {
   @Get('')
   @GetStudyDocs()
   async getAllStudy(): Promise<StudyResponseDto[]> {
-    return this.studyService.findAll();
+    return this.studyService.getStudies();
   }
 }

--- a/src/study/dtos/crew-study-response.dto.ts
+++ b/src/study/dtos/crew-study-response.dto.ts
@@ -1,4 +1,5 @@
 import { MeetingJoinablePart } from './study-response.dto';
+import { CrewPageApiMetaResponseDto } from '../../common/type';
 
 export interface CrewMeetingResponseDto {
   readonly statusCode: number;
@@ -7,6 +8,7 @@ export interface CrewMeetingResponseDto {
 
 export interface CrewMeetingListDto {
   readonly meetings: CrewMeetingDto[];
+  readonly meta: CrewPageApiMetaResponseDto;
 }
 
 export interface CrewMeetingDto {

--- a/src/study/repository/study.repository.ts
+++ b/src/study/repository/study.repository.ts
@@ -17,7 +17,7 @@ export class StudyRepository {
     this.URL = this.configService.get('CREW_API_URL') as string;
   }
 
-  async findStudy({
+  async findAll({
     page = 1,
     limit = 12,
   }: {

--- a/src/study/repository/study.repository.ts
+++ b/src/study/repository/study.repository.ts
@@ -1,6 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { catchError, lastValueFrom, map } from 'rxjs';
+import { AxiosError } from 'axios';
 
 import { EnvConfig } from '../../configs/env.config';
 import { CrewMeetingResponseDto } from '../dtos/crew-study-response.dto';
@@ -35,8 +36,8 @@ export class StudyRepository {
         )
         .pipe(
           map((res) => res.data),
-          catchError((error) => {
-            console.error(error);
+          catchError((error: AxiosError<unknown>) => {
+            console.error(error.response);
             throw new InternalServerErrorException(
               'Get study API Error',
               error.message,

--- a/src/study/repository/study.repository.ts
+++ b/src/study/repository/study.repository.ts
@@ -1,0 +1,48 @@
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { catchError, lastValueFrom, map } from 'rxjs';
+
+import { EnvConfig } from '../../configs/env.config';
+import { CrewMeetingResponseDto } from '../dtos/crew-study-response.dto';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+
+@Injectable()
+export class StudyRepository {
+  private URL: string;
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService<EnvConfig>,
+  ) {
+    this.URL = this.configService.get('CREW_API_URL') as string;
+  }
+
+  async findStudy({
+    page = 1,
+    limit = 12,
+  }: {
+    page: number;
+    limit: number;
+  }): Promise<CrewMeetingResponseDto> {
+    return await lastValueFrom(
+      this.httpService
+        .get<CrewMeetingResponseDto>(
+          `${
+            this.URL
+          }/meeting?isOnlyActiveGeneration=${true}&page=${page}&take=${limit}&category=${encodeURI(
+            '스터디',
+          )}`,
+        )
+        .pipe(
+          map((res) => res.data),
+          catchError((error) => {
+            console.error(error);
+            throw new InternalServerErrorException(
+              'Get study API Error',
+              error.message,
+            );
+          }),
+        ),
+    );
+  }
+}

--- a/src/study/service/study.service.spec.ts
+++ b/src/study/service/study.service.spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StudyService } from './study.service';
+import { StudyRepository } from '../repository/study.repository';
+import { InternalServerErrorException } from '@nestjs/common';
+import { CrewMeetingResponseDto } from '../dtos/crew-study-response.dto';
+
+describe('StudyServiceTest', () => {
+  let studyService: StudyService;
+  let studyRepository: StudyRepository;
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StudyService,
+        {
+          provide: StudyRepository,
+          useValue: {
+            findAll: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    studyService = module.get<StudyService>(StudyService);
+    studyRepository = module.get<StudyRepository>(StudyRepository);
+  });
+
+  it('should be defined', () => {
+    expect(studyService).toBeDefined();
+    expect(studyRepository).toBeDefined();
+  });
+
+  describe('GetStudyCount Method', () => {
+    it('StudyRepository.findAll 메서드에서 Error가 발생하면 getStudyCount의 response는 null이다', async () => {
+      const mockError = new InternalServerErrorException('mock error');
+      studyRepository.findAll = jest.fn().mockRejectedValue(mockError);
+
+      const response = await studyService.getStudyCount();
+
+      expect(response).toBeNull();
+    });
+
+    it('StudyRepository에서 Error가 발생하지 않으면 getStudyCount의 response는 number이다', async () => {
+      const mockResponse: CrewMeetingResponseDto = {
+        statusCode: 200,
+        data: {
+          meetings: [],
+          meta: {
+            page: 1,
+            take: 12,
+            itemCount: 1,
+            pageCount: 1,
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      };
+      studyRepository.findAll = jest.fn().mockResolvedValue(mockResponse);
+
+      const response = await studyService.getStudyCount();
+
+      expect(typeof response).toBe('number');
+    });
+  });
+
+  describe('GetStudies Method', () => {
+    it('StudyRepository FindAll 메서드 에서 Error가 발생하면 getStudies는 Error를 Throw 한다.', async () => {
+      const mockError = new InternalServerErrorException('mock error');
+      studyRepository.findAll = jest.fn().mockRejectedValue(mockError);
+
+      await expect(studyService.getStudies()).rejects.toThrowError(mockError);
+    });
+
+    it('StudyRepository FindAll 메서드 에서 Error가 발생하지 않으면, getStudies는 List를 반환한다.', () => {
+      const mockResponse: CrewMeetingResponseDto = {
+        statusCode: 200,
+        data: {
+          meetings: [],
+          meta: {
+            page: 1,
+            take: 12,
+            itemCount: 0,
+            pageCount: 1,
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        },
+      };
+      studyRepository.findAll = jest.fn().mockResolvedValue(mockResponse);
+
+      const response = studyService.getStudies();
+
+      expect(response).resolves.toEqual(mockResponse.data.meetings);
+      expect(response).resolves.toHaveLength(0);
+    });
+  });
+});

--- a/src/study/service/study.service.ts
+++ b/src/study/service/study.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { catchError, lastValueFrom, map, of } from 'rxjs';
 import { ConfigService } from '@nestjs/config';
 
@@ -13,22 +13,28 @@ import { Cacheable } from '../../common/cache';
 
 @Injectable()
 export class StudyService {
+  private URL: string;
+
   constructor(
     private readonly httpService: HttpService,
     private readonly configService: ConfigService<EnvConfig>,
-  ) {}
+  ) {
+    this.URL = this.configService.get('CREW_API_URL') as string;
+  }
 
   @Cacheable({
     ttl: 30 * 60,
     validate: (value: any) => !(value instanceof Error),
   })
   async findAll(): Promise<StudyResponseDto[]> {
-    const apiUrl = this.configService.get('CREW_API_URL');
-
     return await lastValueFrom(
       this.httpService
         .get<CrewMeetingResponseDto>(
-          `${apiUrl}/meeting?isOnlyActiveGeneration=${true}`,
+          `${
+            this.URL
+          }/meeting?isOnlyActiveGeneration=${true}&page=${1}&take=${50}&category=${encodeURI(
+            '스터디',
+          )}`,
         )
         .pipe(
           map((res) => res.data.data.meetings),
@@ -59,5 +65,41 @@ export class StudyService {
   async findByGeneration(generation: number): Promise<StudyResponseDto[]> {
     const allStudies = await this.findAll();
     return allStudies.filter((study) => study.generation === generation);
+  }
+
+  /**
+   * 공홈 AboutTab에서 StudyCount를 집계할때 사용됩니다.
+   */
+  async getStudyCount(): Promise<number> {
+    const findStudyResponse = await this.findStudy({ page: 1, limit: 1 });
+    return findStudyResponse.data.meta.itemCount;
+  }
+
+  async findStudy({
+    page = 1,
+    limit = 12,
+  }: {
+    page: number;
+    limit: number;
+  }): Promise<CrewMeetingResponseDto> {
+    return await lastValueFrom(
+      this.httpService
+        .get<CrewMeetingResponseDto>(
+          `${
+            this.URL
+          }/meeting?isOnlyActiveGeneration=${true}&page=${page}&take=${limit}&category=${encodeURI(
+            '스터디',
+          )}`,
+        )
+        .pipe(
+          map((res) => res.data),
+          catchError((error) => {
+            throw new InternalServerErrorException(
+              'Get study API Error',
+              error.message,
+            );
+          }),
+        ),
+    );
   }
 }

--- a/src/study/service/study.service.ts
+++ b/src/study/service/study.service.ts
@@ -15,7 +15,7 @@ export class StudyService {
   })
   async getStudies(): Promise<StudyResponseDto[]> {
     const MAX_TAKE_COUNT = 50;
-    const response = await this.studyRepository.findStudy({
+    const response = await this.studyRepository.findAll({
       page: 1,
       limit: MAX_TAKE_COUNT,
     });
@@ -40,7 +40,7 @@ export class StudyService {
    * 공홈 AboutTab에서 StudyCount를 집계할때 사용됩니다.
    */
   async getStudyCount(): Promise<number> {
-    const findStudyResponse = await this.studyRepository.findStudy({
+    const findStudyResponse = await this.studyRepository.findAll({
       page: 1,
       limit: 1,
     });

--- a/src/study/service/study.service.ts
+++ b/src/study/service/study.service.ts
@@ -39,11 +39,15 @@ export class StudyService {
   /**
    * 공홈 AboutTab에서 StudyCount를 집계할때 사용됩니다.
    */
-  async getStudyCount(): Promise<number> {
-    const findStudyResponse = await this.studyRepository.findAll({
-      page: 1,
-      limit: 1,
-    });
-    return findStudyResponse.data.meta.itemCount;
+  async getStudyCount(): Promise<number | null> {
+    try {
+      const findStudyResponse = await this.studyRepository.findAll({
+        page: 1,
+        limit: 1,
+      });
+      return findStudyResponse.data.meta.itemCount;
+    } catch (error) {
+      return null;
+    }
   }
 }

--- a/src/study/service/study.service.ts
+++ b/src/study/service/study.service.ts
@@ -10,7 +10,7 @@ export class StudyService {
   constructor(private readonly studyRepository: StudyRepository) {}
 
   @Cacheable({
-    ttl: 60 * 60,
+    ttl: 7 * 24 * 60 * 60,
     validate: (value: any) => !(value instanceof Error),
   })
   async getStudies(): Promise<StudyResponseDto[]> {

--- a/src/study/study.module.ts
+++ b/src/study/study.module.ts
@@ -2,10 +2,11 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { StudyController } from './controller/study.controller';
 import { StudyService } from './service/study.service';
+import { StudyRepository } from './repository/study.repository';
 
 @Module({
   imports: [HttpModule],
-  providers: [StudyService],
+  providers: [StudyService, StudyRepository],
   controllers: [StudyController],
   exports: [StudyService],
 })


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
- 크루 서버에 스터디 API를 잘못 호출하고 있었어요. AboutTab에서 StudyCount를 Paging Metadata로 들고와야하는데 페이징된 리스트 사이즈를(디폴트 사이즈가 12인..) 가져오고 있었습니다.

## 💻 수정 사항
- 크루팀에서 Study데이터를  FullScan하기로 했어요 ( MaxSize는 50개인데.. 서비스 목적상 스터디 데이터는 엄청 크게 늘어날 사이즈가 같진 않아서..)
- 그 대신에 공홈 서버에서 StudyAPI를 내부적으로 캐시하기로 했어요. API 목적상 거의 정적데이터에 가까워서 판단했습니다. TTL은 1h입니다. 

## 🧪 테스트 방법
- 테스트 코드

## ⛳️ 고민한 점 || 궁굼한 점
- to 영우. 수정된 사항 처럼 StudyAPI를 페이징 API를 사용하지 않고 FullScan을서 공홈 서버에서 캐시를 해도 되는지 ?
## 🎯 리뷰 포인트

## 📁 레퍼런스
