### PR TITLE
fix: increase max content length

### DIFF
--- a/src/internal/playground/playground.repository.ts
+++ b/src/internal/playground/playground.repository.ts
@@ -57,6 +57,7 @@ export class PlaygroundRepository {
             headers: {
               Authorization: this.jwtToken,
             },
+            maxContentLength: 300 * 1024,
           },
         )
         .pipe(map((res) => res.data)),


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
운영서버에서 project tab을 진입하면 이런 에러가 발생하네요.
로컬에서는 따로 발생하진 않습니다. 우선 코드상으로 maxContnetSize를 증가시켜보고 안되면 인스턴스 설정을 해야할 것 같습니다.
+ 그리고 추후엔 API를 페이징으로 잘라야 할 것 같습니다.
![image](https://github.com/sopt-makers/sopt.org-backend/assets/40652160/b3ec5aee-31cf-409b-9bf9-1bb887ca8f23)


## 💻 수정 사항

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
