### PR TITLE
feat: Study API 32기 조회하도록 수정

### DIFF
--- a/src/internal/crew/crew.service.ts
+++ b/src/internal/crew/crew.service.ts
@@ -9,16 +9,20 @@ export class CrewService {
 
   async getStudies(): Promise<StudyResponseDto[]> {
     const MAX_TAKE_COUNT = 50;
-    const response = await this.crewRepository.findAll({
-      page: 1,
-      limit: MAX_TAKE_COUNT,
-    });
+    const PREVIOUS_GEN = 32; // TODO. 임시로 집어넣은 부분이라 추후 클라와 상의 후, 기수를 입력받는 형식으로 API를 수정해야함!
+    const response = await this.crewRepository.findAll(
+      {
+        page: 1,
+        limit: MAX_TAKE_COUNT,
+      },
+      PREVIOUS_GEN,
+    );
 
     return response.data.meetings.map(
       (meeting: CrewMeetingDto): StudyResponseDto => {
         return {
           id: meeting.id,
-          generation: meeting.targetActiveGeneration,
+          generation: meeting.createdGeneration,
           parts: meeting.joinableParts,
           title: meeting.title,
           imageUrl: meeting.imageURL.length ? meeting.imageURL[0].url : null,

--- a/src/internal/crew/dto/crew-study-response.dto.ts
+++ b/src/internal/crew/dto/crew-study-response.dto.ts
@@ -34,6 +34,7 @@ export interface CrewMeetingDto {
   note: string;
   isMentorNeeded: false;
   canJoinOnlyActiveGeneration: false;
+  createdGeneration: number;
   targetActiveGeneration: number | null;
   joinableParts: MeetingJoinablePart[];
   appliedInfo: [


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
공홈 스터디 페이지에서 32기 활동기록에 33기가 조회되고 있어 우선 강제로 32기 수정하도록 하고, 클라와 추후 협의 후 기수를 입력받아 조회하는 형식으로 변경해야 함

## 💻 수정 사항

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
