### PR TITLE
refac: Title Slicing Length Reduce

### DIFF
--- a/src/scraper/scraper.service.ts
+++ b/src/scraper/scraper.service.ts
@@ -170,7 +170,7 @@ export class ScraperService {
 
   private generateTitle(description: string): string {
     if (description.length >= 150) {
-      return description.slice(0, 100);
+      return description.slice(0, 30);
     }
     return description;
   }


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
네이버 블로그 타이틀을 읽어오지 못하는 경우, 설명 앞 부분을 가져오는 것이 너무 길어서 줄이게 되었음

## 💻 수정 사항

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
