### PR TITLE
fix: Docker Ubuntu Deployment No Space Error

### DIFF
--- a/.github/workflows/cd.develop.yml
+++ b/.github/workflows/cd.develop.yml
@@ -65,6 +65,7 @@ jobs:
           sudo docker stop dev-server
           sudo docker rm dev-server
           sudo docker rm -f $(docker ps -qa)
+          sudo docker image prune -f
           sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:latest
           sudo docker run --name dev-server --env-file .env -d -p 3000:3000 -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:latest
-          sudo docker image prune -f
+          

--- a/.github/workflows/cd.prod.yml
+++ b/.github/workflows/cd.prod.yml
@@ -65,6 +65,6 @@ jobs:
           sudo docker stop sopt.org-backend
           sudo docker rm sopt.org-backend
           sudo docker rm -f $(docker ps -qa)
+          sudo docker image prune -f
           sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_PROD_IMAGE }}:latest
           sudo docker run --name sopt.org-backend --env-file .env -d -p 3000:3000 -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_PROD_IMAGE }}:latest
-          sudo docker image prune -f


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
기존 이미지를 지우지 않고 새로운 이미지를 받았을 때, 우분투 서버 도커의 용량 문제로 인하여 Image Pulling 작업이 에러가 나는 경우가 발생함.
따라서, 기존 이미지까지 완전히 삭제하고 새로운 이미지를 땡겨오는 순서로 변경함 -> 서버가 내려가 있는 시간이 늘어날 수 있는 단점 존재.

## 📌 개발 이유

## 💻 수정 사항

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
