### PR TITLE
fix: Internal Cache Max K-V set to 10000

### DIFF
--- a/src/visitor/visitor.module.ts
+++ b/src/visitor/visitor.module.ts
@@ -5,7 +5,11 @@ import { VisitorService } from './service/visitor.service';
 import { CacheModule as NestCacheModule } from '@nestjs/common/cache/cache.module';
 
 @Module({
-  imports: [NestCacheModule.register()],
+  imports: [
+    NestCacheModule.register({
+      max: 10000,
+    }),
+  ],
   providers: [VisitorService],
   controllers: [VisitorController],
   exports: [VisitorService],


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
하루 방문자 수가 최대 100명까지 밖에 저장안되는 이슈 발생

## 📌 개발 이유

## 💻 수정 사항
내부 캐시 오브젝트를 최대 10000개 까지 넣을 수 있도록 변경 (하루 만명이 넘어가면 외부 메모리로 넘겨는 것 고려)

## 🧪 테스트 방법

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스
